### PR TITLE
[14.0][FIX] mis_builder_cash_flow_forecast_contract: remove invalid selection attribute on related field

### DIFF
--- a/mis_builder_cash_flow_forecast_contract/models/res_config_settings.py
+++ b/mis_builder_cash_flow_forecast_contract/models/res_config_settings.py
@@ -19,7 +19,6 @@ class ResConfigSettings(models.TransientModel):
         readonly=False,
     )
     contract_mis_cash_flow_forecast_rule_type = fields.Selection(
-        [("monthly", "Month(s)"), ("yearly", "Year(s)")],
         related="company_id.contract_mis_cash_flow_forecast_rule_type",
         readonly=False,
     )


### PR DESCRIPTION
cc @marcelsavegnago @WesleyOliveira98 

```
2024-12-16 16:54:26,475 1 WARNING backup_demo odoo.fields: res.config.settings.contract_mis_cash_flow_forecast_rule_type: selection attribute will be ignored as the field is related4
```