### PR TITLE
[16.0][FIX] l10n_br_account_service_type_by_partner: _compute_product_fiscal_fields

### DIFF
--- a/l10n_br_account_service_type_by_partner/models/account_move_line.py
+++ b/l10n_br_account_service_type_by_partner/models/account_move_line.py
@@ -9,9 +9,11 @@ from odoo.addons.l10n_br_fiscal.constants.fiscal import FISCAL_IN
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
-    @api.onchange("product_id")
-    def _onchange_product_id_fiscal(self):
-        res = super()._onchange_product_id_fiscal()
+    @api.depends("product_id", "partner_id", "move_id.fiscal_operation_type")
+    def _compute_product_fiscal_fields(self):
+        if self._context.get("skip_compute_product_fiscal_fields"):
+            return
+        res = super()._compute_product_fiscal_fields()
         if self.product_id and self.move_id.fiscal_operation_type == FISCAL_IN:
             partner_service_type = self.partner_id.partner_service_type_ids.filtered(
                 lambda x: x.product_id == self.product_id

--- a/l10n_br_account_service_type_by_partner/tests/test_onchange_service_type.py
+++ b/l10n_br_account_service_type_by_partner/tests/test_onchange_service_type.py
@@ -47,10 +47,10 @@ class TestServiceTypeOnchange(TransactionCase):
             }
         )
 
-    def test_line_onchange_product_sets_partner_service_type(self):
+    def test_line_compute_product_sets_partner_service_type(self):
         line = self.move.invoice_line_ids[0]
         line.partner_id = self.partner
-        line._onchange_product_id_fiscal()
+        line._compute_product_fiscal_fields()
         self.assertEqual(
             line.service_type_id,
             self.service_type_1009,


### PR DESCRIPTION
Na PR https://github.com/OCA/l10n-brazil/pull/4102 da Localização foi mudado o onchange para compute, trazendo isso aqui para o modulo. 