### PR TITLE
[16.0][FIX] l10n_br_account_service_type_by_partner: fix super _compute_product_fiscal_fields

### DIFF
--- a/l10n_br_account_service_type_by_partner/models/account_move_line.py
+++ b/l10n_br_account_service_type_by_partner/models/account_move_line.py
@@ -11,15 +11,15 @@ class AccountMoveLine(models.Model):
 
     @api.depends("product_id", "partner_id", "move_id.fiscal_operation_type")
     def _compute_product_fiscal_fields(self):
-        if self._context.get("skip_compute_product_fiscal_fields"):
-            return
-        res = super()._compute_product_fiscal_fields()
-        if self.product_id and self.move_id.fiscal_operation_type == FISCAL_IN:
-            partner_service_type = self.partner_id.partner_service_type_ids.filtered(
-                lambda x: x.product_id == self.product_id
-            )
-            if partner_service_type:
-                self.service_type_id = partner_service_type.service_type_id
-            else:
-                self.service_type_id = self.product_id.service_type_id
-        return res
+        for line in self:
+            if line.product_id and line.move_id.fiscal_operation_type == FISCAL_IN:
+                partner_service_type = (
+                    line.partner_id.partner_service_type_ids.filtered(
+                        lambda x, product=line.product_id: x.product_id == product
+                    )[:1]
+                )
+                line.service_type_id = (
+                    partner_service_type.service_type_id
+                    if partner_service_type
+                    else line.product_id.service_type_id
+                )


### PR DESCRIPTION
Correção #153

Como agora o `account.move.line` não herda mais `l10n_br_fiscal.document.line.mixin.methods` acabou quebrando esse modulo

<img width="763" height="388" alt="image" src="https://github.com/user-attachments/assets/fde8c444-f503-4c28-9984-3df4e36ff264" />
