### PR TITLE
[16.0][FIX] mis_builder_cash_flow_forecast_purchase: sudo search

### DIFF
--- a/mis_builder_cash_flow_forecast_purchase/models/purchase_order.py
+++ b/mis_builder_cash_flow_forecast_purchase/models/purchase_order.py
@@ -57,7 +57,7 @@ class PurchaseOrder(models.Model):
 
     def _compute_mis_cash_flow_forecast_line_ids(self):
         ForecastLine = self.env["mis.cash_flow.forecast_line"]
-        forecast_lines = ForecastLine.search(
+        forecast_lines = ForecastLine.sudo().search(
             [
                 ("res_model", "=", self._name),
                 ("res_id", "in", self.ids),


### PR DESCRIPTION
Aplicar sudo() na busca do ir.model usada no compute _compute_mis_cash_flow_forecast_line_ids, linha 60 do arquivo mis_builder_cash_flow_forecast_purchase/models/purchase_order.py

cc @WesleyOliveira98 